### PR TITLE
refactor: remove checkboxes from second prompt

### DIFF
--- a/src/skills-builder/skills-builder-modal/select-preferences/JobTitleSelect.jsx
+++ b/src/skills-builder/skills-builder-modal/select-preferences/JobTitleSelect.jsx
@@ -13,9 +13,8 @@ import messages from './messages';
 
 const JobTitleSelect = () => {
   const { formatMessage } = useIntl();
-  const { state, dispatch, algolia } = useContext(SkillsBuilderContext);
+  const { dispatch, algolia } = useContext(SkillsBuilderContext);
   const { searchClient } = algolia;
-  const { currentJobTitle } = state;
 
   const handleCurrentJobTitleSelect = (value) => {
     dispatch(setCurrentJobTitle(value));
@@ -27,20 +26,6 @@ const JobTitleSelect = () => {
         learner_data: {
           current_job_title: value,
         },
-      },
-    );
-  };
-
-  const handleCheckboxChange = (e) => {
-    const { value } = e.target;
-    // only setCurrentJobTitle if the user hasn't selected a current job as we don't want to override their selection
-    if (!currentJobTitle) { dispatch(setCurrentJobTitle(value)); }
-
-    sendTrackEvent(
-      `edx.skills_builder.current_job.${value}`,
-      {
-        app_name: 'skills_builder',
-        category: 'skills_builder',
       },
     );
   };
@@ -59,19 +44,6 @@ const JobTitleSelect = () => {
           />
         </InstantSearch>
       </Form.Label>
-      <Form.Group>
-        <Form.CheckboxSet
-          name="other-occupations"
-          onChange={handleCheckboxChange}
-        >
-          <Form.Checkbox value="student">
-            {formatMessage(messages.studentCheckboxPrompt)}
-          </Form.Checkbox>
-          <Form.Checkbox value="looking_for_work">
-            {formatMessage(messages.currentlyLookingCheckboxPrompt)}
-          </Form.Checkbox>
-        </Form.CheckboxSet>
-      </Form.Group>
     </Stack>
   );
 };

--- a/src/skills-builder/skills-builder-modal/select-preferences/messages.js
+++ b/src/skills-builder/skills-builder-modal/select-preferences/messages.js
@@ -51,16 +51,6 @@ const messages = defineMessages({
     defaultMessage: 'Search and select a job title',
     description: 'Placeholder text for the job title input control.',
   },
-  studentCheckboxPrompt: {
-    id: 'student.checkbox.prompt',
-    defaultMessage: 'I\'m a student',
-    description: 'Label text for the corresponding checkbox',
-  },
-  currentlyLookingCheckboxPrompt: {
-    id: 'currently.looking.checkbox.prompt',
-    defaultMessage: 'I\'m currently looking for work',
-    description: 'Label text for the corresponding checkbox',
-  },
   careerInterestPrompt: {
     id: 'career.interest.prompt',
     defaultMessage: 'What careers are you interested in?',

--- a/src/skills-builder/skills-builder-modal/select-preferences/test/SelectPreferences.test.jsx
+++ b/src/skills-builder/skills-builder-modal/select-preferences/test/SelectPreferences.test.jsx
@@ -34,11 +34,6 @@ describe('select-preferences', () => {
         payload: 'I want to advance my career',
         type: 'SET_GOAL',
       };
-      const expectedStudent = {
-        payload: 'student',
-        type: 'SET_CURRENT_JOB_TITLE',
-      };
-
       const expectedJobTitle = {
         payload: 'Prospector',
         type: 'SET_CURRENT_JOB_TITLE',
@@ -47,16 +42,12 @@ describe('select-preferences', () => {
       const goalSelect = screen.getByTestId('goal-select-dropdown');
       fireEvent.change(goalSelect, { target: { value: 'I want to advance my career' } });
 
-      const checkbox = screen.getByRole('checkbox', { name: 'I\'m a student' });
-      fireEvent.click(checkbox);
-
       const jobTitleInput = screen.getByTestId('job-title-select');
       fireEvent.change(jobTitleInput, { target: { value: 'Prospector' } });
       fireEvent.click(screen.getByRole('button', { name: 'Prospector' }));
 
       expect(screen.getByText('Next, search and select your current job title')).toBeTruthy();
       expect(dispatchMock).toHaveBeenCalledWith(expectedGoal);
-      expect(dispatchMock).toHaveBeenCalledWith(expectedStudent);
       expect(dispatchMock).toHaveBeenCalledWith(expectedJobTitle);
       expect(sendTrackEvent).toHaveBeenCalledWith(
         'edx.skills_builder.goal.select',
@@ -66,13 +57,6 @@ describe('select-preferences', () => {
           learner_data: {
             current_goal: 'I want to advance my career',
           },
-        },
-      );
-      expect(sendTrackEvent).toHaveBeenCalledWith(
-        'edx.skills_builder.current_job.student',
-        {
-          app_name: 'skills_builder',
-          category: 'skills_builder',
         },
       );
       expect(sendTrackEvent).toHaveBeenCalledWith(


### PR DESCRIPTION
This PR will remove the two checkboxes that learners see under the second prompt of Skills Builder. This also removes any messages, events, and tests that relate to these checkboxes ("I am a student" and "I am looking for work"). 