### PR TITLE
fix: product types hook

### DIFF
--- a/src/skills-builder/skills-builder-modal/view-results/data/hooks.js
+++ b/src/skills-builder/skills-builder-modal/view-results/data/hooks.js
@@ -16,7 +16,7 @@ export const useProductTypes = () => {
 
   if (search) {
     // remove the "?" and split the query string at "="
-    const splitString = search.slice(1).split('=');
+    const splitString = search.slice(1).split('&')[0].split('=');
 
     // if the key is not "product_types", use a default setting
     if (splitString[0] !== 'product_types') {

--- a/src/skills-builder/skills-builder-modal/view-results/data/test/hooks.test.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/data/test/hooks.test.jsx
@@ -43,4 +43,14 @@ describe('useProductTypes', () => {
 
     expect(productTypes).toEqual(['boot_camp', 'course']);
   });
+
+  test('returns a filtered list if additional key-value pairs are provided in the query string', () => {
+    global.query_string = '?product_types=boot_camp,course&external_link=true';
+
+    const { result } = renderHook(() => useProductTypes());
+
+    const productTypes = result.current;
+
+    expect(productTypes).toEqual(['boot_camp', 'course']);
+  });
 });


### PR DESCRIPTION
This will fix a small bug in the hook that extracts product types from the query string. Previously, this hook did not account for there being additional key-value pairs in the query string. Now, it will pull just the first key-value pair.

If we expand this functionality in the future, we should consider using a [package to handle the extraction of values from the query string](https://www.npmjs.com/package/query-string).