### PR TITLE
feat: event tracking for updated UI

### DIFF
--- a/src/skills-builder/data/actions.js
+++ b/src/skills-builder/data/actions.js
@@ -3,6 +3,9 @@ import {
   SET_CURRENT_JOB_TITLE,
   ADD_CAREER_INTEREST,
   REMOVE_CAREER_INTEREST,
+  ADD_TO_EXPANDED_LIST,
+  REMOVE_FROM_EXPANDED_LIST,
+  SET_EXPANDED_LIST,
 } from './constants';
 
 export const setGoal = (payload) => ({
@@ -22,5 +25,20 @@ export const addCareerInterest = (payload) => ({
 
 export const removeCareerInterest = (payload) => ({
   type: REMOVE_CAREER_INTEREST,
+  payload,
+});
+
+export const addToExpandedList = (payload) => ({
+  type: ADD_TO_EXPANDED_LIST,
+  payload,
+});
+
+export const removeFromExpandedList = (payload) => ({
+  type: REMOVE_FROM_EXPANDED_LIST,
+  payload,
+});
+
+export const setExpandedList = (payload) => ({
+  type: SET_EXPANDED_LIST,
   payload,
 });

--- a/src/skills-builder/data/constants.js
+++ b/src/skills-builder/data/constants.js
@@ -3,6 +3,9 @@ export const SET_GOAL = 'SET_GOAL';
 export const SET_CURRENT_JOB_TITLE = 'SET_CURRENT_JOB_TITLE';
 export const ADD_CAREER_INTEREST = 'ADD_CAREER_INTEREST';
 export const REMOVE_CAREER_INTEREST = 'REMOVE_CAREER_INTEREST';
+export const ADD_TO_EXPANDED_LIST = 'ADD_TO_EXPANDED_LIST';
+export const REMOVE_FROM_EXPANDED_LIST = 'REMOVE_FROM_EXPANDED_LIST';
+export const SET_EXPANDED_LIST = 'SET_EXPANDED_LIST';
 
 // Stepper keys
 export const STEP1 = 'select-your-preferences';

--- a/src/skills-builder/data/reducer.js
+++ b/src/skills-builder/data/reducer.js
@@ -3,6 +3,9 @@ import {
   SET_CURRENT_JOB_TITLE,
   ADD_CAREER_INTEREST,
   REMOVE_CAREER_INTEREST,
+  ADD_TO_EXPANDED_LIST,
+  REMOVE_FROM_EXPANDED_LIST,
+  SET_EXPANDED_LIST,
 } from './constants';
 
 export function skillsReducer(state, action) {
@@ -27,6 +30,21 @@ export function skillsReducer(state, action) {
         ...state,
         careerInterests: state.careerInterests.filter(interest => interest !== action.payload),
       };
+    case ADD_TO_EXPANDED_LIST:
+      return {
+        ...state,
+        expandedList: [...state.expandedList, action.payload],
+      };
+    case REMOVE_FROM_EXPANDED_LIST:
+      return {
+        ...state,
+        expandedList: state.expandedList.filter(item => item !== action.payload),
+      };
+    case SET_EXPANDED_LIST:
+      return {
+        ...state,
+        expandedList: action.payload,
+      };
     default:
       return state;
   }
@@ -36,6 +54,7 @@ export const skillsInitialState = {
   currentGoal: '',
   currentJobTitle: '',
   careerInterests: [],
+  expandedList: [],
 };
 
 export default skillsReducer;

--- a/src/skills-builder/data/test/reducer.test.js
+++ b/src/skills-builder/data/test/reducer.test.js
@@ -4,6 +4,9 @@ import {
   SET_CURRENT_JOB_TITLE,
   ADD_CAREER_INTEREST,
   REMOVE_CAREER_INTEREST,
+  ADD_TO_EXPANDED_LIST,
+  REMOVE_FROM_EXPANDED_LIST,
+  SET_EXPANDED_LIST,
 } from '../constants';
 
 describe('skillsReducer', () => {
@@ -55,6 +58,52 @@ describe('skillsReducer', () => {
       // override the 'careerInterests` field and remove 'test-career-interest' from the array
       careerInterests: testStateWithInterest.careerInterests.filter(interest => interest !== newCareerInterestPayload),
     };
+    expect(returnedState).toEqual(finalState);
+  });
+
+  it('adds to the list of expanded recommendations', () => {
+    const newPayload = 'course';
+    const returnedState = skillsReducer(
+      testState,
+      { type: ADD_TO_EXPANDED_LIST, payload: newPayload },
+    );
+    const finalState = {
+      ...testState,
+      expandedList: [newPayload],
+    };
+
+    expect(returnedState).toEqual(finalState);
+  });
+
+  it('removes from the list of expanded recommendations', () => {
+    const newPayload = 'course';
+    const testStateWithPayload = {
+      ...testState,
+      expandedList: [newPayload],
+    };
+    const returnedState = skillsReducer(
+      testStateWithPayload,
+      { type: REMOVE_FROM_EXPANDED_LIST, payload: newPayload },
+    );
+    const finalState = {
+      ...testState,
+      expandedList: [],
+    };
+
+    expect(returnedState).toEqual(finalState);
+  });
+
+  it('modifies the list of expanded recommendations', () => {
+    const newPayload = ['course', 'boot_camp'];
+    const returnedState = skillsReducer(
+      testState,
+      { type: SET_EXPANDED_LIST, payload: newPayload },
+    );
+    const finalState = {
+      ...testState,
+      expandedList: newPayload,
+    };
+
     expect(returnedState).toEqual(finalState);
   });
 });

--- a/src/skills-builder/skills-builder-modal/skillsBuilderModal.scss
+++ b/src/skills-builder/skills-builder-modal/skillsBuilderModal.scss
@@ -8,6 +8,12 @@
   max-width: 18rem;
 }
 
+.product-card {
+  .chip-max-width {
+    max-width: 100%;
+  }
+}
+
 $breakpoint-medium: 992px;
 @media (max-width: $breakpoint-medium) {
   .med-min-height {
@@ -21,13 +27,5 @@ $breakpoint-medium: 992px;
   }
   .overflow-scroll-medium {
     overflow: scroll;
-}
-}
-
-@media (min-width: $breakpoint-medium) {
-  .product-card {
-    .chip-max-width {
-      width: 100%;
-    }
   }
 }

--- a/src/skills-builder/skills-builder-modal/view-results/ProductCardGrid.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/ProductCardGrid.jsx
@@ -12,15 +12,16 @@ const ProductCardGrid = ({
       md: 6,
       lg: 3,
     }}
-    hasEqualColumnHeights
+    hasEqualColumnHeights={false}
   >
     {isExpanded ? (
-      productTypeRecommendations?.map(rec => (
+      productTypeRecommendations?.map((rec, index) => (
         <RecommendationCard
           key={rec.uuid}
           handleCourseCardClick={handleCourseCardClick}
           rec={rec}
           productType={productTypeName}
+          indexInList={index}
         />
       ))
     ) : (

--- a/src/skills-builder/skills-builder-modal/view-results/ProductTypeBanner.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/ProductTypeBanner.jsx
@@ -21,6 +21,7 @@ const ProductTypeBanner = ({
   const isLarge = useMediaQuery({ minWidth: breakpoints.large.minWidth });
 
   const normalizeProductTitle = () => {
+    // construct the title text based on the provided productTypeName
     switch (productTypeName) {
       case COURSE:
         return formatMessage(messages.productTypeCourseText);
@@ -67,6 +68,7 @@ const ProductTypeBanner = ({
   };
 
   const infoStackProps = {
+    // props for the Stack with description, number of results, and "Show all" button
     gap: 2,
     direction: isLarge ? 'horizontal' : 'vertical',
     className: 'justify-content-between align-items-start',
@@ -75,7 +77,7 @@ const ProductTypeBanner = ({
   const showAllButtonProps = {
     variant: 'link',
     className: 'p-0',
-    onClick: () => handleShowAllButtonClick(productTypeName),
+    onClick: () => handleShowAllButtonClick(productTypeName, numberResults),
     'aria-expanded': isExpanded ? 'true' : 'false',
     'aria-controls': `card-grid-${productTypeName}`,
     'data-testid': `${productTypeName}-expand-button`,

--- a/src/skills-builder/skills-builder-modal/view-results/RecommendationCard.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/RecommendationCard.jsx
@@ -5,7 +5,9 @@ import {
 import PropTypes from 'prop-types';
 import cardImageCapFallbackSrc from '../../images/card-imagecap-fallback.png';
 
-const RecommendationCard = ({ rec, productType, handleCourseCardClick }) => {
+const RecommendationCard = ({
+  rec, productType, handleCourseCardClick, indexInList,
+}) => {
   const {
     card_image_url: cardImageUrl,
     marketing_url: marketingUrl,
@@ -19,14 +21,14 @@ const RecommendationCard = ({ rec, productType, handleCourseCardClick }) => {
 
   return (
     <Card
+      as={Hyperlink}
+      target="_blank"
+      showLaunchIcon={false}
+      destination={marketingUrl}
       className="product-card"
-      onClick={() => handleCourseCardClick(courseKey, productType)}
+      onClick={() => handleCourseCardClick(courseKey, productType, indexInList)}
     >
       <Card.ImageCap
-        as={Hyperlink}
-        destination={marketingUrl}
-        target="_blank"
-        showLaunchIcon={false}
         src={cardImageUrl}
         logoSrc={logoImageUrl}
         fallbackSrc={cardImageCapFallbackSrc}
@@ -59,6 +61,11 @@ RecommendationCard.propTypes = {
   }).isRequired,
   productType: PropTypes.string.isRequired,
   handleCourseCardClick: PropTypes.func.isRequired,
+  indexInList: PropTypes.number,
+};
+
+RecommendationCard.defaultProps = {
+  indexInList: 0,
 };
 
 export default RecommendationCard;

--- a/src/skills-builder/skills-builder-modal/view-results/RecommendationStack.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/RecommendationStack.jsx
@@ -1,15 +1,40 @@
-import React, { useState } from 'react';
+import React, { useContext } from 'react';
 import { Stack } from '@edx/paragon';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import ProductCardGrid from './ProductCardGrid';
 import ProductTypeBanner from './ProductTypeBanner';
+import { addToExpandedList, removeFromExpandedList } from '../../data/actions';
+import { SkillsBuilderContext } from '../../skills-builder-context';
 import { extractProductKeys } from '../../utils/extractProductKeys';
 
 const RecommendationStack = ({ selectedRecommendations, productTypeNames }) => {
-  const [showAllButtonClickedList, setShowButtonClickedList] = useState([]);
+  const { state, dispatch } = useContext(SkillsBuilderContext);
+  const { expandedList } = state;
   const { id: jobId, name: jobName, recommendations } = selectedRecommendations;
 
-  const handleCourseCardClick = (courseKey, productTypeName) => {
+  const handleCourseCardClick = (courseKey, productTypeName, index) => {
+    // check to see if the grid of recommendations for this product line has been expanded
+    if (expandedList.includes(productTypeName)) {
+      // fire expanded click event
+      sendTrackEvent(
+        'edx.skills_builder.recommendation.expanded.click',
+        {
+          app_name: 'skills_builder',
+          category: 'skills_builder',
+          page: 'skills_builder',
+          courserun_key: courseKey,
+          product_line: productTypeName,
+          index_in_list: index,
+          selected_recommendations: {
+            job_id: jobId,
+            job_name: jobName,
+            product_keys: extractProductKeys(recommendations, [...expandedList, productTypeName]),
+          },
+        },
+      );
+      return;
+    }
+    // otherwise, fire normal click event
     sendTrackEvent(
       'edx.skills_builder.recommendation.click',
       {
@@ -17,29 +42,52 @@ const RecommendationStack = ({ selectedRecommendations, productTypeNames }) => {
         category: 'skills_builder',
         page: 'skills_builder',
         courserun_key: courseKey,
-        product_type: productTypeName,
+        product_line: productTypeName,
         selected_recommendations: {
           job_id: jobId,
           job_name: jobName,
-          courserun_keys: extractProductKeys(recommendations),
+          product_keys: extractProductKeys(recommendations, [...expandedList, productTypeName]),
         },
       },
     );
   };
 
-  const handleShowAllButtonClick = (type) => {
-    if (showAllButtonClickedList.includes(type)) {
-      setShowButtonClickedList(prev => prev.filter(item => item !== type));
+  const handleShowAllButtonClick = (type, numberResults) => {
+    // check if button is expanded
+    if (expandedList.includes(type)) {
+      dispatch(removeFromExpandedList(type));
       return;
     }
-    setShowButtonClickedList(prev => [...prev, type]);
+    // if not, add it to the list of expanded product lines
+    dispatch(addToExpandedList(type));
+    // fire event for clicking the "Show all" button
+    sendTrackEvent('edx.skills_builder.show_all.click', {
+      app_name: 'skills_builder',
+      category: 'skills_builder',
+      page: 'skills_builder',
+      product_line: type,
+      number_recommendations: numberResults,
+    });
+    // fire separate event for the recommendations that were shown when expanded
+    sendTrackEvent('edx.skills_builder.recommendation.expanded.shown', {
+      app_name: 'skills_builder',
+      category: 'skills_builder',
+      page: 'skills_builder',
+      product_line: type,
+      selected_recommendations: {
+        job_id: jobId,
+        job_name: jobName,
+        product_keys: extractProductKeys(recommendations, [...expandedList, type]),
+      },
+    });
   };
 
   return (
     productTypeNames.map(productTypeName => {
+      // the recommendations object has a key for each productTypeName
       const productTypeRecommendations = recommendations[productTypeName];
       const numberResults = productTypeRecommendations?.length;
-      const isExpanded = showAllButtonClickedList.includes(productTypeName);
+      const isExpanded = expandedList.includes(productTypeName);
 
       return (
         <Stack gap={2.5} key={productTypeName}>

--- a/src/skills-builder/utils/extractProductKeys.js
+++ b/src/skills-builder/utils/extractProductKeys.js
@@ -1,17 +1,42 @@
 import { productTypeNames } from '../skills-builder-modal/view-results/data/constants';
 
-export const extractProductKeys = (recommendations) => (
+/**
+* Utility function for extracting product keys from a list of recommendations.
+* This is used to help minimize the payload that is sent with Segment events.
+*
+* @param
+*   @typedef recommendations - an object with a key for each product line
+*   @type {object}
+*   @property {array[object]} product_line - each object contains many fields for a given recommendation
+* @param
+*   @typedef expandedList - used to determine which product_lines have been expanded, defaults to empty
+*   @type {array}
+*
+* @return
+*   @typedef productKeys - an object with a key for each product line
+*   @type {object}
+*   @property {array[object]} product_line - each object contains a title and product key
+*/
+export const extractProductKeys = (recommendations, expandedList = []) => (
   Object.fromEntries(
-    productTypeNames.map(type => (
-      [
+    // first map through each productTypeName
+    productTypeNames.map(type => {
+      // for each type, determine if it is expanded or not
+      const recommendationsRefinedList = expandedList.includes(type)
+        // if it is, return all recommendations
+        ? recommendations[type]
+        // if not, only return the first 4
+        : recommendations[type].slice(0, 4);
+      return [
         type,
-        recommendations[type]?.map(rec => ({
+        // create an array of objects for each product line
+        // each object contains a title and product key, rather than the entire response from Algolia (rec)
+        recommendationsRefinedList.map(rec => ({
           title: rec.title,
           courserun_key: rec.active_run_key,
         })),
-      ]
-    )),
-  )
-);
+      ];
+    }),
+  ));
 
 export default extractProductKeys;


### PR DESCRIPTION
This PR adds new events to the updated UI for product recommendations in the Skills Builder. [This document](https://2u-internal.atlassian.net/wiki/spaces/microb/pages/452853855/Updates+for+Recs+KPIs) was used to make these updates.

There has been a significant addition to the `SkillsBuilderContext`. The list that keeps track of which product lines are expanded has been given it's own field called `expandedList` in the `SkillsBuilderContext`. This field has three actions: `ADD_TO_EXPANDED_LIST`, `REMOVE_FROM_EXPANDED_LIST`, `SET_EXPANDED_LIST`. We can use these actions throughout the app to maintain a reference to the shown recommendations. This is especially important for our Segment events because we need a denominator when determining the effectiveness of our application/recommendations.

In order to minimize the amount of data that is passed to Segment, we have employed an `extractProductKeys` utility function that serves to extract a small amount of data from the initial response. The initial response from Algolia is quite large and would cause our Segment events to fail silently in the pipeline ([Segment docs](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/troubleshooting/#is-there-a-size-limit-on-requests)). `extractProductKeys` will make the overall payload in the event much smaller.