### PR TITLE
fix: extractProductKeys breaking recommendations view

### DIFF
--- a/src/skills-builder/skills-builder-modal/view-results/ViewResults.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/ViewResults.jsx
@@ -4,6 +4,7 @@ import React, {
 import {
   Stack, Row, Alert, Spinner,
 } from '@edx/paragon';
+import { logError } from '@edx/frontend-platform/logging';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { CheckCircle, ErrorOutline } from '@edx/paragon/icons';
@@ -56,7 +57,8 @@ const ViewResults = () => {
     };
 
     getAllRecommendations()
-      .catch(() => {
+      .catch((err) => {
+        logError(err);
         setFetchError(true);
         setIsLoading(false);
       });

--- a/src/skills-builder/utils/extractProductKeys.js
+++ b/src/skills-builder/utils/extractProductKeys.js
@@ -26,12 +26,12 @@ export const extractProductKeys = (recommendations, expandedList = []) => (
         // if it is, return all recommendations
         ? recommendations[type]
         // if not, only return the first 4
-        : recommendations[type].slice(0, 4);
+        : recommendations[type]?.slice(0, 4);
       return [
         type,
         // create an array of objects for each product line
         // each object contains a title and product key, rather than the entire response from Algolia (rec)
-        recommendationsRefinedList.map(rec => ({
+        recommendationsRefinedList?.map(rec => ({
           title: rec.title,
           courserun_key: rec.active_run_key,
         })),


### PR DESCRIPTION
This will address an error that was discovered in Skills Builder where recommendations were not being returned, despite seeing a successful in the Network tab. The application was failing silently because we didn't have proper logging for catching these errors. This has been added and the utility function that was causing the error has been modified to prevent it from happening again. More details in the ticket below:

[APER-2690](https://2u-internal.atlassian.net/jira/software/c/projects/APER/boards/585?modal=detail&selectedIssue=APER-2690)

A test has been added and it has been confirmed that this test will fail if these changes to `extractProductKeys` are removed.