### PR TITLE
fix: Search icon for Autosuggest

### DIFF
--- a/src/skills-builder/skills-builder-modal/select-preferences/JobTitleInstantSearch.jsx
+++ b/src/skills-builder/skills-builder-modal/select-preferences/JobTitleInstantSearch.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Form,
+  Form, Icon,
 } from '@edx/paragon';
 import { useHits, useSearchBox } from 'react-instantsearch-hooks-web';
+import { Search } from '@edx/paragon/icons';
 
 const JobTitleInstantSearch = (props) => {
   const { refine } = useSearchBox(props);
@@ -25,6 +26,12 @@ const JobTitleInstantSearch = (props) => {
       onChange={handleAutosuggestChange}
       name="job-title-suggest"
       autoComplete="off"
+      trailingElement={(
+        <Icon
+          src={Search}
+          className="mr-2"
+        />
+        )}
       {...props}
     >
       {hits.map(job => (


### PR DESCRIPTION
Paragon has built-in props forwarding for the `Form.Autosuggest` component. See [here](https://github.com/openedx/paragon/blob/master/src/Form/FormAutosuggest.jsx#L227).

This means we only need to pass the icon in as a prop for `Form.Autosuggest` and Paragon will forward it to the corresponding `FormControl` component, which accepts a `trailingElement`.

The fix is to pass `trailingElement` with a value of the new icon to the component. This will override the default dropdown icon. 

It's worth noting that there are some accessibility features associated with the default icon. The alt text (and the icon itself) will change depending on whether or not the dropdown has been open. There is no easy way to do this with the Search icon. The state that manages the expanding of the list is tucked away inside the Paragon component. 

A more elegant fix would be modifying Paragon to support custom icons, but that would require a little more investment on both our part and the Paragon Working Group. Although, at that point we are essentially outfitting our `Autosuggest` to be a `SearchBox`. Perhaps then what we really need is an entirely new `SearchBox` component in Paragon. All of this is out of scope for the [current ticket](https://2u-internal.atlassian.net/browse/APER-2689). That being said, given that the Search icon is essentially just decorative, it didn't seem like the alt text should even be there at all so it has not been included.


<img width="976" alt="Screenshot 2023-07-25 at 9 48 29 AM" src="https://github.com/edx/frontend-app-skills/assets/92897870/7f24ef52-19a9-4e23-a5c9-ab9a1c2cf337">

