### PR TITLE
fix: recommendation click event

### DIFF
--- a/src/skills-builder/skills-builder-modal/view-results/RecommendationStack.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/RecommendationStack.jsx
@@ -28,7 +28,7 @@ const RecommendationStack = ({ selectedRecommendations, productTypeNames }) => {
           selected_recommendations: {
             job_id: jobId,
             job_name: jobName,
-            product_keys: extractProductKeys(recommendations, [...expandedList, productTypeName]),
+            product_keys: extractProductKeys(recommendations, expandedList),
           },
         },
       );
@@ -47,7 +47,7 @@ const RecommendationStack = ({ selectedRecommendations, productTypeNames }) => {
         selected_recommendations: {
           job_id: jobId,
           job_name: jobName,
-          product_keys: extractProductKeys(recommendations, [...expandedList, productTypeName]),
+          product_keys: extractProductKeys(recommendations, expandedList),
         },
       },
     );


### PR DESCRIPTION
When we fire the events for clicking on recommendations, we are passing an array (`expandedList`) to the `extractProductKeys` function. This utility function will use that array to determine which LOBs have been expanded in the UI. 

When clicking on the "Show All" button, we have to make sure to add on the current product type because the `expandedList` that is stored in Context will not be updated by the time this event goes to fire.

https://github.com/edx/frontend-app-skills/blob/41ee70d79922baaf9471d61540cf9aacced07a8e/src/skills-builder/skills-builder-modal/view-results/RecommendationStack.jsx#L81

This code was unnecessarily duplicated in the two recommendation click events: `edx.skills_builder.recommendaition.expanded.click` and `edx.skills_builder.recommendaition.click`. This led to an error where clicking on a card in an unexpanded list of cards generated a payload with the expanded list instead.