### PR TITLE
fix: Don't show a line of business with no results

### DIFF
--- a/src/skills-builder/skills-builder-modal/view-results/RecommendationStack.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/RecommendationStack.jsx
@@ -90,6 +90,9 @@ const RecommendationStack = ({ selectedRecommendations, productTypeNames }) => {
       const numberResults = productTypeRecommendations?.length;
       const isExpanded = expandedList.includes(productTypeName);
 
+      if (numberResults === 0) {
+        return null;
+      }
       return (
         <Stack gap={2.5} key={productTypeName}>
           <ProductTypeBanner

--- a/src/skills-builder/skills-builder-modal/view-results/test/ViewResults.test.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/test/ViewResults.test.jsx
@@ -152,21 +152,29 @@ describe('view-results', () => {
       expect(screen.getByText(messages.productTypeCourseDescription.defaultMessage)).toBeTruthy();
     });
 
-    it('hides a LOB if there are no results', async () => {
-      getProductRecommendations.mockImplementation((productIndex, productType) => {
-        if (productType === 'boot_camp') {
+    describe('Product lines are hidden with no results', () => {
+      beforeAll(() => {
+        getProductRecommendations.mockImplementation((productIndex, productType) => {
+          if (productType === 'boot camp') {
+            return [];
+          }
           return mockData.productRecommendations;
-        }
-        return [];
+        });
+        // Is there a more elegant way to restore the mocK?
+        afterEach(() => {
+          getProductRecommendations.mockImplementation(() => (
+            mockData.productRecommendations
+          ));
+        });
       });
-
-      // This one should not be true - no recommendations provided
-      expect(screen.getByText(messages.productTypeBootCampDescription.defaultMessage)).toBeFalsy();
-      // These should all work.
-      expect(screen.getByText(messages.productTypeDegreeDescription.defaultMessage)).toBeTruthy();
-      expect(screen.getByText(messages.productTypeExecutiveEducationDescription.defaultMessage)).toBeTruthy();
-      expect(screen.getByText(messages.productTypeProgramDescription.defaultMessage)).toBeTruthy();
-      expect(screen.getByText(messages.productTypeCourseDescription.defaultMessage)).toBeTruthy();
+      it('hides a LOB if there are no results', async () => {
+        expect(screen.queryByText(messages.productTypeBootCampDescription.defaultMessage)).toBeNull();
+        // These should all work.
+        expect(screen.getByText(messages.productTypeDegreeDescription.defaultMessage)).toBeTruthy();
+        expect(screen.getByText(messages.productTypeExecutiveEducationDescription.defaultMessage)).toBeTruthy();
+        expect(screen.getByText(messages.productTypeProgramDescription.defaultMessage)).toBeTruthy();
+        expect(screen.getByText(messages.productTypeCourseDescription.defaultMessage)).toBeTruthy();
+      });
     });
   });
 

--- a/src/skills-builder/skills-builder-modal/view-results/test/ViewResults.test.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/test/ViewResults.test.jsx
@@ -160,7 +160,7 @@ describe('view-results', () => {
           }
           return mockData.productRecommendations;
         });
-        // Is there a more elegant way to restore the mocK?
+        // Restore the mock to the expected value for the other tests.
         afterEach(() => {
           getProductRecommendations.mockImplementation(() => (
             mockData.productRecommendations

--- a/src/skills-builder/skills-builder-modal/view-results/test/ViewResults.test.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/test/ViewResults.test.jsx
@@ -151,6 +151,23 @@ describe('view-results', () => {
       expect(screen.getByText(messages.productTypeProgramDescription.defaultMessage)).toBeTruthy();
       expect(screen.getByText(messages.productTypeCourseDescription.defaultMessage)).toBeTruthy();
     });
+
+    it('hides a LOB if there are no results', async () => {
+      getProductRecommendations.mockImplementation((productIndex, productType) => {
+        if (productType === 'boot_camp') {
+          return mockData.productRecommendations;
+        }
+        return [];
+      });
+
+      // This one should not be true - no recommendations provided
+      expect(screen.getByText(messages.productTypeBootCampDescription.defaultMessage)).toBeFalsy();
+      // These should all work.
+      expect(screen.getByText(messages.productTypeDegreeDescription.defaultMessage)).toBeTruthy();
+      expect(screen.getByText(messages.productTypeExecutiveEducationDescription.defaultMessage)).toBeTruthy();
+      expect(screen.getByText(messages.productTypeProgramDescription.defaultMessage)).toBeTruthy();
+      expect(screen.getByText(messages.productTypeCourseDescription.defaultMessage)).toBeTruthy();
+    });
   });
 
   describe('show all button', () => {


### PR DESCRIPTION
Check if each LOB has returned results, and don't show the section for that LOB in that case.
Putting up a message when there are no results for any LOBs is coming in a separate ticket.