### PR TITLE
fix: log errors on no results

### DIFF
--- a/src/skills-builder/skills-builder-modal/view-results/ViewResults.jsx
+++ b/src/skills-builder/skills-builder-modal/view-results/ViewResults.jsx
@@ -54,6 +54,21 @@ const ViewResults = () => {
         },
         is_default: true,
       });
+
+      // Check if any LOB doesn't have a recommendation for a job
+      results.forEach((jobResult) => {
+        let hasAnyRecommendations = false;
+        productTypes.current.forEach((lob) => {
+          if (jobResult.recommendations[lob].length === 0) {
+            logError(`Job [${jobResult.name}] has no recommendations for ${lob}`);
+          } else {
+            hasAnyRecommendations = true;
+          }
+        });
+        if (!hasAnyRecommendations) {
+          logError(`Job [${jobResult.name}] has no recommendations for any LOB in [${productTypes.current}]`);
+        }
+      });
     };
 
     getAllRecommendations()


### PR DESCRIPTION
Log an error when there are no results for an LOB, and also when there are no requests for any LOB.
