### PR TITLE
feat: remove progressive disclosure

### DIFF
--- a/src/skills-builder/skills-builder-modal/select-preferences/SelectPreferences.jsx
+++ b/src/skills-builder/skills-builder-modal/select-preferences/SelectPreferences.jsx
@@ -1,9 +1,8 @@
-import React, { useContext, useRef } from 'react';
+import React, { useRef } from 'react';
 import {
   Stack,
 } from '@edx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { SkillsBuilderContext } from '../../skills-builder-context';
 import { useVisibilityFlags } from '../view-results/data/hooks';
 import GoalSelect from './GoalSelect';
 import JobTitleSelect from './JobTitleSelect';
@@ -12,10 +11,8 @@ import messages from './messages';
 
 const SelectPreferences = () => {
   const { formatMessage } = useIntl();
-  const { state } = useContext(SkillsBuilderContext);
-  const { currentGoal, currentJobTitle } = state;
   const visibilityFlags = useRef(useVisibilityFlags());
-  const { showGoal, showCurrentJobTitle, alwaysShowCareerInterest } = visibilityFlags.current;
+  const { showGoal, showCurrentJobTitle, showCareerInterest } = visibilityFlags.current;
 
   return (
     <Stack gap={4}>
@@ -23,15 +20,15 @@ const SelectPreferences = () => {
         {formatMessage(messages.skillsBuilderDescription)}
       </p>
       <Stack gap={4}>
-        { showGoal && (
+        {showGoal && (
           <GoalSelect />
         )}
 
-        {currentGoal && showCurrentJobTitle && (
+        {showCurrentJobTitle && (
           <JobTitleSelect />
         )}
 
-        {(alwaysShowCareerInterest || (currentGoal && currentJobTitle)) && (
+        {showCareerInterest && (
           <CareerInterestSelect />
         )}
       </Stack>

--- a/src/skills-builder/skills-builder-modal/view-results/data/constants.js
+++ b/src/skills-builder/skills-builder-modal/view-results/data/constants.js
@@ -35,7 +35,7 @@ export const DEFAULT_VISIBILITY_FLAGS = {
   showCareerInterestCards: true,
   showGoal: true,
   showCurrentJobTitle: true,
-  alwaysShowCareerInterest: false,
+  showCareerInterest: true,
   isProgressive: false,
 };
 
@@ -46,6 +46,6 @@ export const ONE_QUESTION_VISIBILITY_FLAGS = {
   showCareerInterestCards: false,
   showGoal: false,
   showCurrentJobTitle: false,
-  alwaysShowCareerInterest: true,
+  showCareerInterest: true,
   isProgressive: true,
 };


### PR DESCRIPTION
This removes progressive disclosure from the Skills Builder. Now all questions will be shown to the learner regardless of what stage they are in the form. Each question is also easily configurable using the query string extraction technique that was set up previously.