### PR TITLE
fix: clean up UI to match figma

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prop-types": "15.8.1",
         "react": "16.14.0",
         "react-dom": "16.14.0",
-        "react-instantsearch-hooks-web": "^6.40.1",
+        "react-instantsearch": "^7.0.2",
         "react-redux": "7.2.9",
         "react-router": "5.3.4",
         "react-router-dom": "5.3.4",
@@ -12303,40 +12303,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
-    "node_modules/instantsearch.js": {
-      "version": "4.56.8",
-      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.56.8.tgz",
-      "integrity": "sha512-40DJ5l70ZzVzWPK3qrHTKlJLaHGq1PRZpzfL6281P2mz8G19WOHQHKAP4Zh6a4lOZaRtJQUiPjQwqCHSurXZ5g==",
-      "dependencies": {
-        "@algolia/events": "^4.0.1",
-        "@algolia/ui-components-highlight-vdom": "^1.2.1",
-        "@algolia/ui-components-shared": "^1.2.1",
-        "@types/dom-speech-recognition": "^0.0.1",
-        "@types/google.maps": "^3.45.3",
-        "@types/hogan.js": "^3.0.0",
-        "@types/qs": "^6.5.3",
-        "algoliasearch-helper": "3.14.0",
-        "hogan.js": "^3.0.2",
-        "htm": "^3.0.0",
-        "preact": "^10.10.0",
-        "qs": "^6.5.1 < 6.10",
-        "search-insights": "^2.6.0"
-      },
-      "peerDependencies": {
-        "algoliasearch": ">= 3.1 < 6"
-      }
-    },
-    "node_modules/instantsearch.js/node_modules/qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/internal-slot": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
@@ -19882,15 +19848,29 @@
         }
       }
     },
-    "node_modules/react-instantsearch-hooks": {
-      "version": "6.47.3",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-hooks/-/react-instantsearch-hooks-6.47.3.tgz",
-      "integrity": "sha512-QuGSwZ664MHrzvndXGnsyPhpKHywGqyDgqOVorYpEE24Y063OPv5XtmJaZqn27MIvvByUormTb6dbPgbjqkd8w==",
-      "deprecated": "package has moved to react-instantsearch-core",
+    "node_modules/react-instantsearch": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-instantsearch/-/react-instantsearch-7.0.2.tgz",
+      "integrity": "sha512-RDaOJzkVTQ0TSLnvYqFmuQyTUh2FmSyNRsDMQ/CVv3BxsMS9bRR6xn8bo31vnDu7Eg95S5ydt/1JBl+uqt0PAA==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2",
+        "instantsearch.js": "4.56.10",
+        "react-instantsearch-core": "7.0.2"
+      },
+      "peerDependencies": {
+        "algoliasearch": ">= 3.1 < 5",
+        "react": ">= 16.8.0 < 19",
+        "react-dom": ">= 16.8.0 < 19"
+      }
+    },
+    "node_modules/react-instantsearch-core": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-7.0.2.tgz",
+      "integrity": "sha512-g1yDcEiKTKs6U8VbiqmM0tcBLWvi7lPLIWgOSGfWe5hqh62Z8U0WEhtdQwVxiNf5W0I1DGxWzgBJ/V8m9MBtaA==",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
         "algoliasearch-helper": "3.14.0",
-        "instantsearch.js": "4.56.8",
+        "instantsearch.js": "4.56.10",
         "use-sync-external-store": "^1.0.0"
       },
       "peerDependencies": {
@@ -19898,20 +19878,72 @@
         "react": ">= 16.8.0 < 19"
       }
     },
-    "node_modules/react-instantsearch-hooks-web": {
-      "version": "6.47.3",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-hooks-web/-/react-instantsearch-hooks-web-6.47.3.tgz",
-      "integrity": "sha512-JTkPm11xwCX9eO4FgeeJ4v4O98wz1L7cAa2LkspgzDD1MPjMLtmiRVzvGxuYnOayQTtfC5+0GOBwuJEN8TDI8A==",
-      "deprecated": "package has moved to react-instantsearch",
+    "node_modules/react-instantsearch-core/node_modules/instantsearch.js": {
+      "version": "4.56.10",
+      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.56.10.tgz",
+      "integrity": "sha512-ViW2JGUgxcDaQ9/3CRBPrw0fK63XalsZnZhohYgdVZLAdacgGUPO8txWLJ5g2477XHtMS1T4sTYlyCyDIcCQ8A==",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "instantsearch.js": "4.56.8",
-        "react-instantsearch-hooks": "6.47.3"
+        "@algolia/events": "^4.0.1",
+        "@algolia/ui-components-highlight-vdom": "^1.2.1",
+        "@algolia/ui-components-shared": "^1.2.1",
+        "@types/dom-speech-recognition": "^0.0.1",
+        "@types/google.maps": "^3.45.3",
+        "@types/hogan.js": "^3.0.0",
+        "@types/qs": "^6.5.3",
+        "algoliasearch-helper": "3.14.0",
+        "hogan.js": "^3.0.2",
+        "htm": "^3.0.0",
+        "preact": "^10.10.0",
+        "qs": "^6.5.1 < 6.10",
+        "search-insights": "^2.6.0"
       },
       "peerDependencies": {
-        "algoliasearch": ">= 3.1 < 5",
-        "react": ">= 16.8.0 < 19",
-        "react-dom": ">= 16.8.0 < 19"
+        "algoliasearch": ">= 3.1 < 6"
+      }
+    },
+    "node_modules/react-instantsearch-core/node_modules/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/react-instantsearch/node_modules/instantsearch.js": {
+      "version": "4.56.10",
+      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.56.10.tgz",
+      "integrity": "sha512-ViW2JGUgxcDaQ9/3CRBPrw0fK63XalsZnZhohYgdVZLAdacgGUPO8txWLJ5g2477XHtMS1T4sTYlyCyDIcCQ8A==",
+      "dependencies": {
+        "@algolia/events": "^4.0.1",
+        "@algolia/ui-components-highlight-vdom": "^1.2.1",
+        "@algolia/ui-components-shared": "^1.2.1",
+        "@types/dom-speech-recognition": "^0.0.1",
+        "@types/google.maps": "^3.45.3",
+        "@types/hogan.js": "^3.0.0",
+        "@types/qs": "^6.5.3",
+        "algoliasearch-helper": "3.14.0",
+        "hogan.js": "^3.0.2",
+        "htm": "^3.0.0",
+        "preact": "^10.10.0",
+        "qs": "^6.5.1 < 6.10",
+        "search-insights": "^2.6.0"
+      },
+      "peerDependencies": {
+        "algoliasearch": ">= 3.1 < 6"
+      }
+    },
+    "node_modules/react-instantsearch/node_modules/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/react-intl": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prop-types": "15.8.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
-    "react-instantsearch-hooks-web": "^6.40.1",
+    "react-instantsearch": "^7.0.2",
     "react-redux": "7.2.9",
     "react-router": "5.3.4",
     "react-router-dom": "5.3.4",

--- a/src/skills-builder/skills-builder-steps/SkillsBuilderDefault.jsx
+++ b/src/skills-builder/skills-builder-steps/SkillsBuilderDefault.jsx
@@ -46,13 +46,12 @@ const SkillsBuilderDefault = () => {
   };
 
   return (
-    <div className="min-vh-100">
+    <div className="min-vh-100 bg-light-200">
       <SkillsBuilderHeader isMedium={isMedium} />
       <Stepper activeKey={currentStep}>
 
-        <Stepper.Header compactWidth="md" />
-
-        <Container size="md" className="p-4.5">
+        <Stepper.Header compactWidth="md" className="bg-white mb-4.5" />
+        <Container size="md">
           <Form>
             <Stepper.Step eventKey={STEP1} title={formatMessage(messages.selectPreferences)}>
               <SelectPreferences />
@@ -71,7 +70,7 @@ const SkillsBuilderDefault = () => {
               </Button>
             </Stepper.ActionRow>
 
-            <Stepper.ActionRow eventKey={STEP2}>
+            <Stepper.ActionRow eventKey={STEP2} className="py-4.5">
               <Button variant="outline-primary" onClick={() => setCurrentStep(STEP1)}>
                 {formatMessage(messages.goBackButton)}
               </Button>

--- a/src/skills-builder/skills-builder-steps/messages.js
+++ b/src/skills-builder/skills-builder-steps/messages.js
@@ -1,7 +1,7 @@
 import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
-  /* Modal Action Row Buttons */
+  /* Action Row Buttons */
   goBackButton: {
     id: 'go.back.button',
     defaultMessage: 'Go Back',

--- a/src/skills-builder/skills-builder-steps/select-preferences/CareerInterestCategorizinator.jsx
+++ b/src/skills-builder/skills-builder-steps/select-preferences/CareerInterestCategorizinator.jsx
@@ -16,7 +16,7 @@ const CareerInterestCategorizinator = () => {
   const { state, dispatch } = useContext(SkillsBuilderContext);
   const { careerInterests } = state;
   const visibilityFlags = useRef(useVisibilityFlags());
-  const { showCareerInterestCards, allowMultipleCareerInterests } = visibilityFlags.current;
+  const { showCareerInterestCards, allowMultipleCareerInterests, isProgressive } = visibilityFlags.current;
 
   const handleCareerInterestSelect = (value) => {
     if (!allowMultipleCareerInterests && careerInterests.length > 0) {
@@ -61,11 +61,17 @@ const CareerInterestCategorizinator = () => {
   };
 
   return (
-    <Stack gap={2}>
+    <Stack>
       <Form.Label>
-        <h4 className="mb-3">
-          {formatMessage(messages.careerInterestPrompt)}
-        </h4>
+        {isProgressive ? (
+          <p className="lead">
+            {formatMessage(messages.careerInterestPromptProgressive)}
+          </p>
+        ) : (
+          <h4 className="mb-3">
+            {formatMessage(messages.careerInterestPrompt)}
+          </h4>
+        )}
       </Form.Label>
       <Stack
         direction="horizontal"

--- a/src/skills-builder/skills-builder-steps/select-preferences/CareerInterestSelect.jsx
+++ b/src/skills-builder/skills-builder-steps/select-preferences/CareerInterestSelect.jsx
@@ -5,7 +5,7 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import {
   Stack, Row, Col, Form,
 } from '@edx/paragon';
-import { Configure, InstantSearch } from 'react-instantsearch-hooks-web';
+import { Configure, InstantSearch } from 'react-instantsearch';
 import JobTitleInstantSearch from './JobTitleInstantSearch';
 import CareerInterestCard from './CareerInterestCard';
 import { addCareerInterest, clearAllCareerInterests } from '../../data/actions';

--- a/src/skills-builder/skills-builder-steps/select-preferences/JobTitleInstantSearch.jsx
+++ b/src/skills-builder/skills-builder-steps/select-preferences/JobTitleInstantSearch.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import {
   Form, Icon,
 } from '@edx/paragon';
-import { useHits, useSearchBox } from 'react-instantsearch-hooks-web';
+import { useSearchBox, useInstantSearch } from 'react-instantsearch';
 import { Search } from '@edx/paragon/icons';
 
 const JobTitleInstantSearch = (props) => {
   const { refine } = useSearchBox(props);
-  const { hits } = useHits(props);
+  const { results, status } = useInstantSearch();
+  const { hits } = results;
 
   const [jobInput, setJobInput] = useState('');
 
@@ -26,6 +27,7 @@ const JobTitleInstantSearch = (props) => {
       onChange={handleAutosuggestChange}
       name="job-title-suggest"
       autoComplete="off"
+      isLoading={status === 'loading' || status === 'stalled'}
       trailingElement={(
         <Icon
           src={Search}

--- a/src/skills-builder/skills-builder-steps/select-preferences/JobTitleSelect.jsx
+++ b/src/skills-builder/skills-builder-steps/select-preferences/JobTitleSelect.jsx
@@ -5,7 +5,7 @@ import {
 } from '@edx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { InstantSearch } from 'react-instantsearch-hooks-web';
+import { InstantSearch } from 'react-instantsearch';
 import { setCurrentJobTitle } from '../../data/actions';
 import { SkillsBuilderContext } from '../../skills-builder-context';
 import JobTitleInstantSearch from './JobTitleInstantSearch';

--- a/src/skills-builder/skills-builder-steps/select-preferences/SelectPreferences.jsx
+++ b/src/skills-builder/skills-builder-steps/select-preferences/SelectPreferences.jsx
@@ -2,24 +2,18 @@ import React, { useRef } from 'react';
 import {
   Stack,
 } from '@edx/paragon';
-import { useIntl } from '@edx/frontend-platform/i18n';
 import { useVisibilityFlags } from '../view-results/data/hooks';
 import GoalSelect from './GoalSelect';
 import JobTitleSelect from './JobTitleSelect';
 import CareerInterestSelect from './CareerInterestSelect';
 import CareerInterestCategorizinator from './CareerInterestCategorizinator';
-import messages from './messages';
 
 const SelectPreferences = () => {
-  const { formatMessage } = useIntl();
   const visibilityFlags = useRef(useVisibilityFlags());
   const { showGoal, showCurrentJobTitle, showCategorizinator } = visibilityFlags.current;
 
   return (
     <Stack gap={4}>
-      <p className="lead">
-        {formatMessage(messages.skillsBuilderDescription)}
-      </p>
       <Stack gap={4}>
         {showGoal && (
           <GoalSelect />

--- a/src/skills-builder/skills-builder-steps/select-preferences/messages.js
+++ b/src/skills-builder/skills-builder-steps/select-preferences/messages.js
@@ -8,7 +8,7 @@ const messages = defineMessages({
   },
   learningGoalPrompt: {
     id: 'learning.goal.prompt',
-    defaultMessage: 'First, tell us what you want to achieve',
+    defaultMessage: 'First, tell us what you want to achieve (optional)',
     description: 'Prompts the user to select their current goal.',
   },
   selectLearningGoal: {
@@ -43,7 +43,7 @@ const messages = defineMessages({
   },
   jobTitlePrompt: {
     id: 'job.title.prompt',
-    defaultMessage: 'Next, search and select your current job title',
+    defaultMessage: 'Next, search and select your current job title (optional)',
     description: 'Prompts the user to select their current job title or occupation.',
   },
   jobTitleInputPlaceholderText: {
@@ -56,6 +56,11 @@ const messages = defineMessages({
     defaultMessage: 'What careers are you interested in?',
     description: 'Prompts the user to select careers they are interested in pursuing.',
   },
+  careerInterestPromptProgressive: {
+    id: 'career.interest.prompt.progressive',
+    defaultMessage: 'Select a job from the categories below to see related skills and courses',
+    description: 'Prompts the user to select careers they are interested in pursuing for the "Progressive" view.',
+  },
   careerInterestInputPlaceholderText: {
     id: 'career.interest.input.placeholder.text',
     defaultMessage: 'Select up to 3 new job titles',
@@ -66,7 +71,6 @@ const messages = defineMessages({
     defaultMessage: 'Select a new job title',
     description: 'Placeholder text for the career interest input control for one choice.',
   },
-
   removeCareerInterestButtonAltText: {
     id: 'career.interest.remove.button.alt.text',
     defaultMessage: 'Remove career interest: ',

--- a/src/skills-builder/skills-builder-steps/select-preferences/test/SelectPreferences.test.jsx
+++ b/src/skills-builder/skills-builder-steps/select-preferences/test/SelectPreferences.test.jsx
@@ -46,7 +46,7 @@ describe('select-preferences', () => {
       fireEvent.change(jobTitleInput, { target: { value: 'Prospector' } });
       fireEvent.click(screen.getByRole('button', { name: 'Prospector' }));
 
-      expect(screen.getByText('Next, search and select your current job title')).toBeTruthy();
+      expect(screen.getByText('Next, search and select your current job title (optional)')).toBeTruthy();
       expect(dispatchMock).toHaveBeenCalledWith(expectedGoal);
       expect(dispatchMock).toHaveBeenCalledWith(expectedJobTitle);
       expect(sendTrackEvent).toHaveBeenCalledWith(

--- a/src/skills-builder/skills-builder-steps/skillsBuilderSteps.scss
+++ b/src/skills-builder/skills-builder-steps/skillsBuilderSteps.scss
@@ -3,12 +3,6 @@
   object-fit: contain;
 }
 
-.skills-builder-modal {
-  button[aria-label="Close"][type="button"]{
-    color: $white;
-  }
-}
-
 .chip-max-width {
   max-width: 18rem;
 }
@@ -23,12 +17,6 @@ $breakpoint-medium: 992px;
 @media (max-width: $breakpoint-medium) {
   .med-min-height {
     min-height: map-get($spacers, 6);
-  }
-  .skills-builder-modal {
-    button[aria-label="Close"][type="button"]{
-      position: relative;
-      top: 0.5rem;
-    }
   }
   .overflow-scroll-medium {
     overflow: scroll;

--- a/src/skills-builder/skills-builder-steps/view-results/RelatedSkillsSingleBoxSet.jsx
+++ b/src/skills-builder/skills-builder-steps/view-results/RelatedSkillsSingleBoxSet.jsx
@@ -39,10 +39,9 @@ const RelatedSkillsSingleBoxSet = ({ jobSkillsList }) => {
   return (
     showSkillsBox
     && (
-    <Card>
+    <Card className="mt-4.5">
       <Card.Header
         title={name}
-        size="sm"
       />
       { showSkillsList
         && (

--- a/src/skills-builder/skills-builder-steps/view-results/ViewResults.jsx
+++ b/src/skills-builder/skills-builder-steps/view-results/ViewResults.jsx
@@ -131,7 +131,7 @@ const ViewResults = () => {
 
   return (
     isLoading ? (
-      <Row>
+      <Row className="vh-100">
         <Spinner
           animation="border"
           screenReaderText="loading"
@@ -139,7 +139,7 @@ const ViewResults = () => {
         />
       </Row>
     ) : (
-      <Stack gap={4.5} className="py-4.5">
+      <Stack gap={4.5}>
         { showMatchesFoundAlert && (
           <Alert
             variant="success"

--- a/src/skills-builder/skills-builder-steps/view-results/data/constants.js
+++ b/src/skills-builder/skills-builder-steps/view-results/data/constants.js
@@ -30,7 +30,8 @@ productTypeParams[PROGRAM_PARAM] = PROGRAM;
 // visibility flag sets
 // Default visibility flags - the version that appears if no special flags are set
 export const DEFAULT_VISIBILITY_FLAGS = {
-  showMatchesFoundAlert: true,
+  // TODO: we can probably deprecate this setting entirely as we don't intend to use this alert again
+  showMatchesFoundAlert: false,
   isInteractiveBoxSet: false,
   showCareerInterestCards: true,
   showGoal: true,
@@ -46,6 +47,7 @@ export const DEFAULT_VISIBILITY_FLAGS = {
 
 // Show a single question, and go right to the recommendations
 export const ONE_QUESTION_VISIBILITY_FLAGS = {
+  // TODO: we can probably deprecate this setting entirely as we don't intend to use this alert again
   showMatchesFoundAlert: false,
   isInteractiveBoxSet: true,
   showCareerInterestCards: false,

--- a/src/skills-builder/test/SkillsBuilder.test.jsx
+++ b/src/skills-builder/test/SkillsBuilder.test.jsx
@@ -21,7 +21,7 @@ describe('skills-builder', () => {
     jest.clearAllMocks();
   });
 
-  it('should render a Skills Builder modal with a prompt for the user', () => {
+  it('should render a Skills Builder with a prompt for the user', () => {
     act(() => {
       render(
         <IntlProvider locale="en">
@@ -32,6 +32,6 @@ describe('skills-builder', () => {
       );
     });
     expect(screen.getByText('Skills Builder')).toBeTruthy();
-    expect(screen.getByText('First, tell us what you want to achieve')).toBeTruthy();
+    expect(screen.getByText('First, tell us what you want to achieve (optional)')).toBeTruthy();
   });
 });

--- a/src/skills-builder/test/setupSkillsBuilder.jsx
+++ b/src/skills-builder/test/setupSkillsBuilder.jsx
@@ -8,12 +8,12 @@ import { getProductRecommendations, searchJobs, useAlgoliaSearch } from '../util
 
 jest.mock('@edx/frontend-platform/logging');
 
-jest.mock('react-instantsearch-hooks-web', () => ({
+jest.mock('react-instantsearch', () => ({
   // eslint-disable-next-line react/prop-types
   InstantSearch: ({ children }) => (<div>{children}</div>),
   Configure: jest.fn(() => (null)),
   useSearchBox: jest.fn(() => ({ refine: jest.fn() })),
-  useHits: jest.fn(() => ({ hits: mockData.hits })),
+  useInstantSearch: jest.fn(() => ({ results: { hits: mockData.hits } })),
 }));
 
 jest.mock('react-router-dom', () => ({


### PR DESCRIPTION
This PR addresses some quick fixes that were discovered while testing in Stage environment and comparing with the [latest Figma design](https://www.figma.com/file/CqfySHGfIn4GIEcj1NdAAE/Skills-Builder-V-1.1---1.2?type=design&node-id=348%3A13753&mode=dev).

Additionally, the `react-instantsearch-web-hooks` package has been upgraded to v7. For this upgrade, the package name has changed to `react-instantsearch`. We are using a new hook from this package as well called `useInstantSearch`. This enables us to provide a loading indicator to the `Form.Autosuggest` component which makes for a better user experience. There is now feedback when the search is loading or stalled.

### Screenshots

#### Default (step 1)
<img width="1063" alt="Screenshot 2023-09-07 at 12 45 04 PM" src="https://github.com/edx/frontend-app-skills/assets/92897870/f1681ceb-9e24-4f5e-9ded-cd2a1d8aec8b">

#### Default (step 2)
<img width="1144" alt="Screenshot 2023-09-07 at 1 46 03 PM" src="https://github.com/edx/frontend-app-skills/assets/92897870/dafe6179-6490-467f-8b22-7025adeaffef">

#### Single Page
<img width="1144" alt="Screenshot 2023-09-07 at 1 44 19 PM" src="https://github.com/edx/frontend-app-skills/assets/92897870/0c32acb4-4ecd-401d-99f4-fc6d82062526">


 