### PR TITLE
fix: goal select copy changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-edx.org@^2.1.2",
-        "@edx/frontend-component-footer": "12.2.1",
+        "@edx/frontend-component-footer-edx": "^6.4.0",
         "@edx/frontend-platform": "4.6.3",
         "@edx/paragon": "^20.20.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -3238,76 +3238,78 @@
         "node": ">=6"
       }
     },
-    "node_modules/@edx/frontend-component-footer": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-12.2.1.tgz",
-      "integrity": "sha512-0ZeuFsnToS7h7qI4yXo6FKVz+c4vDyqP2nhPMR3xm3xgPOmHvf8KNL6ES/YGb+ptPYb64ZxT2iNBP6DY0wF3uQ==",
+    "node_modules/@edx/frontend-component-footer-edx": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer-edx/-/frontend-component-footer-edx-6.4.0.tgz",
+      "integrity": "sha512-1Kx/alLLzaLYWB/p1N0a31Nwf2NSNpAzgNmK53/fpqt7lZGZYwVGeGppX6c4EaYCfz0NgBDvGa43QiZAJDvb9g==",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "6.4.2",
-        "@fortawesome/free-brands-svg-icons": "6.4.2",
-        "@fortawesome/free-regular-svg-icons": "6.4.2",
-        "@fortawesome/free-solid-svg-icons": "6.4.2",
-        "@fortawesome/react-fontawesome": "0.2.0"
+        "@fortawesome/fontawesome-svg-core": "6.4.0",
+        "@fortawesome/free-brands-svg-icons": "6.4.0",
+        "@fortawesome/free-regular-svg-icons": "6.4.0",
+        "@fortawesome/free-solid-svg-icons": "6.4.0",
+        "@fortawesome/react-fontawesome": "0.2.0",
+        "js-cookie": "^3.0.1"
       },
       "peerDependencies": {
         "@edx/frontend-platform": "^4.0.0 || ^5.0.0",
-        "prop-types": "^15.5.10",
+        "@edx/paragon": "^20.0.0",
+        "prop-types": "^15.7.0",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
-    "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.2.tgz",
-      "integrity": "sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA==",
+    "node_modules/@edx/frontend-component-footer-edx/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.2.tgz",
-      "integrity": "sha512-gjYDSKv3TrM2sLTOKBc5rH9ckje8Wrwgx1CxAPbN5N3Fm4prfi7NsJVWd1jklp7i5uSCVwhZS5qlhMXqLrpAIg==",
+    "node_modules/@edx/frontend-component-footer-edx/node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+      "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.4.2"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/free-brands-svg-icons": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.2.tgz",
-      "integrity": "sha512-LKOwJX0I7+mR/cvvf6qIiqcERbdnY+24zgpUSouySml+5w8B4BJOx8EhDR/FTKAu06W12fmUIcv6lzPSwYKGGg==",
+    "node_modules/@edx/frontend-component-footer-edx/node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-qvxTCo0FQ5k2N+VCXb/PZQ+QMhqRVM4OORiO6MXdG6bKolIojGU/srQ1ptvKk0JTbRgaJOfL2qMqGvBEZG7Z6g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.4.2"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/free-regular-svg-icons": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.2.tgz",
-      "integrity": "sha512-0+sIUWnkgTVVXVAPQmW4vxb9ZTHv0WstOa3rBx9iPxrrrDH6bNLsDYuwXF9b6fGm+iR7DKQvQshUH/FJm3ed9Q==",
+    "node_modules/@edx/frontend-component-footer-edx/node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.4.2"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.2.tgz",
-      "integrity": "sha512-sYwXurXUEQS32fZz9hVCUUv/xu49PEJEyUOsA51l6PU/qVgfbTb2glsTEaJngVVT8VqBATRIdh7XVgV1JF1LkA==",
+    "node_modules/@edx/frontend-component-footer-edx/node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.4.2"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       },
       "engines": {
         "node": ">=6"
@@ -17392,6 +17394,14 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
       "integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ==",
       "peer": true
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-edx.org@^2.1.2",
-    "@edx/frontend-component-footer": "12.2.1",
+    "@edx/frontend-component-footer-edx": "^6.4.0",
     "@edx/frontend-platform": "4.6.3",
     "@edx/paragon": "^20.20.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,4 +1,4 @@
-import { messages as footerMessages } from '@edx/frontend-component-footer';
+import { messages as footerMessages } from '@edx/frontend-component-footer-edx';
 
 import arMessages from './messages/ar.json';
 import caMessages from './messages/ca.json';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,7 +7,7 @@ import {
 import { AppProvider, ErrorPage, PageRoute } from '@edx/frontend-platform/react';
 import ReactDOM from 'react-dom';
 
-import Footer from '@edx/frontend-component-footer';
+import Footer from '@edx/frontend-component-footer-edx';
 import { SkillsBuilder } from './skills-builder';
 import messages from './i18n';
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -3,7 +3,7 @@
 @import "@edx/paragon/scss/core/core.scss";
 @import "@edx/brand/paragon/overrides.scss";
 
-@import "~@edx/frontend-component-footer/dist/footer";
+@import "~@edx/frontend-component-footer-edx/dist/footer";
 
 @import './skills-builder/skills-builder-steps/skillsBuilderSteps.scss';
 @import './skills-builder/skills-builder-header/skillsBuilderHeader.scss';

--- a/src/skills-builder/skills-builder-steps/select-preferences/CareerInterestCategorizinator.jsx
+++ b/src/skills-builder/skills-builder-steps/select-preferences/CareerInterestCategorizinator.jsx
@@ -6,7 +6,7 @@ import {
 } from '@edx/paragon';
 import { Verified } from '@edx/paragon/icons';
 import CareerInterestCard from './CareerInterestCard';
-import { addCareerInterest, clearAllCareerInterests } from '../../skills-builder-context/data/actions';
+import { addCareerInterest, clearAllCareerInterests, setExpandedList } from '../../skills-builder-context/data/actions';
 import { SkillsBuilderContext } from '../../skills-builder-context';
 import messages from './messages';
 import { careerList } from '../../utils/jobsByCategory';
@@ -21,6 +21,8 @@ const CareerInterestCategorizinator = () => {
   const { showCareerInterestCards, allowMultipleCareerInterests, isProgressive } = visibilityFlagsState;
 
   const handleCareerInterestSelect = (value) => {
+    // TODO: test event payload
+    dispatch(setExpandedList([]));
     if (!allowMultipleCareerInterests && careerInterests.length > 0) {
       dispatch(clearAllCareerInterests(value));
     }

--- a/src/skills-builder/skills-builder-steps/select-preferences/GoalSelect.jsx
+++ b/src/skills-builder/skills-builder-steps/select-preferences/GoalSelect.jsx
@@ -46,8 +46,7 @@ const GoalDropdown = () => {
         <option>{formatMessage(messages.learningGoalStartCareer)}</option>
         <option>{formatMessage(messages.learningGoalAdvanceCareer)}</option>
         <option>{formatMessage(messages.learningGoalChangeCareer)}</option>
-        <option>{formatMessage(messages.learningGoalSomethingNew)}</option>
-        <option>{formatMessage(messages.learningGoalSomethingElse)}</option>
+        <option>{formatMessage(messages.learningGoalExplore)}</option>
       </Form.Control>
     </Form.Group>
   );

--- a/src/skills-builder/skills-builder-steps/select-preferences/messages.js
+++ b/src/skills-builder/skills-builder-steps/select-preferences/messages.js
@@ -31,6 +31,11 @@ const messages = defineMessages({
     defaultMessage: 'I want to change careers',
     description: 'Selected by user if their goal is to change careers.',
   },
+  learningGoalExplore: {
+    id: 'learning.goal.explore',
+    defaultMessage: 'I want to explore',
+    description: 'Selected by user if their goal is to explore.',
+  },
   learningGoalSomethingNew: {
     id: 'learning.goal.something.new',
     defaultMessage: 'I want to learn something new',

--- a/src/skills-builder/skills-builder-steps/view-results/ViewResults.jsx
+++ b/src/skills-builder/skills-builder-steps/view-results/ViewResults.jsx
@@ -38,6 +38,7 @@ const ViewResults = () => {
 
   useEffect(() => {
     const getAllRecommendations = async () => {
+      setIsLoading(true);
       // eslint-disable-next-line max-len
       const { jobInfo, results } = await getRecommendations(jobSearchIndex, productSearchIndex, careerInterests, productTypes.current);
       if (results[0]) {


### PR DESCRIPTION
### Goal select copy changes

The goals now read:
- I want to start my career
- I want to advance my career
- I want to change my career
- I want to explore

### Other changes

The footer was previously set to use the openedx footer as most MFEs are set up this way and then are aliased with our `edx-internal` configuration. It now pull directly from the `edx` brand footer as we don't have aliasing set up for this MFE.

The `isLoading` boolean is set to true while querying for results. This will display the loading spinner in between selections for the single page version ("Glide path") of the Skills Builder.