### PR TITLE
chore: remove codecov action from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Default CI
-on: 
+on:
   push:
     branches:
       - 'master'
@@ -29,5 +29,3 @@ jobs:
       run: npm run build
     - name: i18n_extract
       run: npm run i18n_extract
-    - name: Coverage
-      uses: codecov/codecov-action@v3


### PR DESCRIPTION
CodeCov has been complaining about requiring a token for a *long* time. CodeCov isn't available on repos in the `edx` GitHub org, it is only available for repos/projects of the Open edX org (`openedx`).

This PR removes the step to try and generate a coverage report, which has just been failing anyway.

This also means it's one less dependency for Renovate to try and update.