### PR TITLE
chore: upgrade alogliasearch

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -19,5 +19,3 @@ SITE_NAME=localhost
 USER_INFO_COOKIE_NAME='edx-user-info'
 APP_ID=''
 MFE_CONFIG_API_URL=''
-ALGOLIA_JOBS_INDEX_NAME='jobs-index'
-ALGOLIA_PRODUCT_INDEX_NAME='product-index'

--- a/.env.test
+++ b/.env.test
@@ -19,3 +19,5 @@ SITE_NAME=localhost
 USER_INFO_COOKIE_NAME='edx-user-info'
 APP_ID=''
 MFE_CONFIG_API_URL=''
+ALGOLIA_JOBS_INDEX_NAME='jobs-index'
+ALGOLIA_PRODUCT_INDEX_NAME='product-index'

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fortawesome/free-solid-svg-icons": "6.6.0",
         "@fortawesome/react-fontawesome": "0.2.2",
         "@openedx/paragon": "^22.0.0",
-        "algoliasearch": "4.24.0",
+        "algoliasearch": "^5.14.2",
         "core-js": "3.39.0",
         "prop-types": "15.8.1",
         "react": "17.0.2",
@@ -38,75 +38,103 @@
         "jest": "29.7.0"
       }
     },
-    "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
-      "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.14.2.tgz",
+      "integrity": "sha512-7fq1tWIy1aNJEaNHxWy3EwDkuo4k22+NBnxq9QlYVSLLXtr6HqmAm6bQgNNzGT3vm21iKqWO9efk+HIhEM1SzQ==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/cache-common": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/cache-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
-      "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g=="
-    },
-    "node_modules/@algolia/cache-in-memory": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
-      "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
-      "dependencies": {
-        "@algolia/cache-common": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/client-account": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
-      "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
-      "dependencies": {
-        "@algolia/client-common": "4.24.0",
-        "@algolia/client-search": "4.24.0",
-        "@algolia/transporter": "4.24.0"
+        "@algolia/client-common": "5.14.2",
+        "@algolia/requester-browser-xhr": "5.14.2",
+        "@algolia/requester-fetch": "5.14.2",
+        "@algolia/requester-node-http": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
-      "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.14.2.tgz",
+      "integrity": "sha512-5Nm5cOOyAGcY+hKNJVmR2jgoGn1nvoANS8W5EfB8yAaUqUxL3lFNUHSkFafAMTCOcVKNDkZQYjUDbOOfdYJLqw==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.24.0",
-        "@algolia/client-search": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
+        "@algolia/client-common": "5.14.2",
+        "@algolia/requester-browser-xhr": "5.14.2",
+        "@algolia/requester-fetch": "5.14.2",
+        "@algolia/requester-node-http": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
-      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.14.2.tgz",
+      "integrity": "sha512-BW1Qzhh9tMKEsWSQQsiOEcHAd6g7zxq9RpPVmyxbDO/O4eA4vyN+Qz5Jzo686kuYdIQKqIPCEtob/JM89tk57g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.14.2.tgz",
+      "integrity": "sha512-17zg6pqifKORvvrMIqW6HhwUry9RKRXLgADrgFjZ6PZvGB4oVs12dwRG2/HMrIlpxd9cjeQfdlEgHj6lbAf6QA==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
+        "@algolia/client-common": "5.14.2",
+        "@algolia/requester-browser-xhr": "5.14.2",
+        "@algolia/requester-fetch": "5.14.2",
+        "@algolia/requester-node-http": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
-      "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.14.2.tgz",
+      "integrity": "sha512-5IYt8vbmTA52xyuaZKFwiRoDPeh7hiOC9aBZqqp9fVs6BU01djI/T8pGJXawvwczltCPYzNsdbllV3rqiDbxmQ==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
+        "@algolia/client-common": "5.14.2",
+        "@algolia/requester-browser-xhr": "5.14.2",
+        "@algolia/requester-fetch": "5.14.2",
+        "@algolia/requester-node-http": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.14.2.tgz",
+      "integrity": "sha512-gvCX/cczU76Bu1sGcxxTdoIwxe+FnuC1IlW9SF/gzxd3ZzsgzBpzD2puIJqt9fHQsjLxVGkJqKev2FtExnJYZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.14.2",
+        "@algolia/requester-browser-xhr": "5.14.2",
+        "@algolia/requester-fetch": "5.14.2",
+        "@algolia/requester-node-http": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
-      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.14.2.tgz",
+      "integrity": "sha512-0imdBZDjqxrshw0+eyJUgnkRAbS2W93UQ3BVj8VjN4xQylIMf0fWs72W7MZFdHlH78JJYydevgzqvGMcV0Z1CA==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/transporter": "4.24.0"
+        "@algolia/client-common": "5.14.2",
+        "@algolia/requester-browser-xhr": "5.14.2",
+        "@algolia/requester-fetch": "5.14.2",
+        "@algolia/requester-node-http": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -114,66 +142,85 @@
       "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
-    "node_modules/@algolia/logger-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
-      "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA=="
-    },
-    "node_modules/@algolia/logger-console": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
-      "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
+    "node_modules/@algolia/ingestion": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.14.2.tgz",
+      "integrity": "sha512-/p4rBNkW0fgCpCwrwre+jHfzlFQsLemgaAQqyui8NPxw95Wgf3p+DKxYzcmh8dygT7ub7FwztTW+uURLX1uqIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/logger-common": "4.24.0"
+        "@algolia/client-common": "5.14.2",
+        "@algolia/requester-browser-xhr": "5.14.2",
+        "@algolia/requester-fetch": "5.14.2",
+        "@algolia/requester-node-http": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.14.2.tgz",
+      "integrity": "sha512-81R57Y/mS0uNhWpu6cNEfkbkADLW4bP0BNjuPpxAypobv7WzYycUnbMvv1YkN6OsociB4+3M7HfsVzj4Nc09vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.14.2",
+        "@algolia/requester-browser-xhr": "5.14.2",
+        "@algolia/requester-fetch": "5.14.2",
+        "@algolia/requester-node-http": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
-      "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.14.2.tgz",
+      "integrity": "sha512-OwELnAZxCUyfjYjqsrFmC7Vfa12kqwbDdLUV0oi4j+4pxDsfPgkiZ6iCH2uPw6X8VK88Hl3InPt+RPaZvcrCWg==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.24.0",
-        "@algolia/cache-common": "4.24.0",
-        "@algolia/cache-in-memory": "4.24.0",
-        "@algolia/client-common": "4.24.0",
-        "@algolia/client-search": "4.24.0",
-        "@algolia/logger-common": "4.24.0",
-        "@algolia/logger-console": "4.24.0",
-        "@algolia/requester-browser-xhr": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/requester-node-http": "4.24.0",
-        "@algolia/transporter": "4.24.0"
+        "@algolia/client-common": "5.14.2",
+        "@algolia/requester-browser-xhr": "5.14.2",
+        "@algolia/requester-fetch": "5.14.2",
+        "@algolia/requester-node-http": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
-      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.14.2.tgz",
+      "integrity": "sha512-irUvkK+TGBhyivtNCIIbVgNUgbUoHOSk8m/kFX4ddto/PUPmLFRRNNnMHtJ1+OzrJ/uD3Am4FUK2Yt+xgQr05w==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.24.0"
+        "@algolia/client-common": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/requester-common": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
-      "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA=="
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.14.2.tgz",
+      "integrity": "sha512-UNBg5mM4MIYdxPuVjyDL22BC6P87g7WuM91Z1Ky0J19aEGvCSF+oR+9autthROFXdRnAa1rACOjuqn95iBbKpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
-      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.14.2.tgz",
+      "integrity": "sha512-CTFA03YiLcnpP+JoLRqjHt5pqDHuKWJpLsIBY/60Gmw8pjALZ3TwvbAquRX4Vy+yrin178NxMuU+ilZ54f2IrQ==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/requester-common": "4.24.0"
-      }
-    },
-    "node_modules/@algolia/transporter": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
-      "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
-      "dependencies": {
-        "@algolia/cache-common": "4.24.0",
-        "@algolia/logger-common": "4.24.0",
-        "@algolia/requester-common": "4.24.0"
+        "@algolia/client-common": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4983,25 +5030,27 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
-      "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.14.2.tgz",
+      "integrity": "sha512-aYjI4WLamMxbhdJ2QAA99VbDCJOGzMOdT2agh57bi40n86ufkhZSIAf6mkocr7NmtBLtwCnSHvD5NJ+Ky5elWw==",
+      "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.24.0",
-        "@algolia/cache-common": "4.24.0",
-        "@algolia/cache-in-memory": "4.24.0",
-        "@algolia/client-account": "4.24.0",
-        "@algolia/client-analytics": "4.24.0",
-        "@algolia/client-common": "4.24.0",
-        "@algolia/client-personalization": "4.24.0",
-        "@algolia/client-search": "4.24.0",
-        "@algolia/logger-common": "4.24.0",
-        "@algolia/logger-console": "4.24.0",
-        "@algolia/recommend": "4.24.0",
-        "@algolia/requester-browser-xhr": "4.24.0",
-        "@algolia/requester-common": "4.24.0",
-        "@algolia/requester-node-http": "4.24.0",
-        "@algolia/transporter": "4.24.0"
+        "@algolia/client-abtesting": "5.14.2",
+        "@algolia/client-analytics": "5.14.2",
+        "@algolia/client-common": "5.14.2",
+        "@algolia/client-insights": "5.14.2",
+        "@algolia/client-personalization": "5.14.2",
+        "@algolia/client-query-suggestions": "5.14.2",
+        "@algolia/client-search": "5.14.2",
+        "@algolia/ingestion": "1.14.2",
+        "@algolia/monitoring": "1.14.2",
+        "@algolia/recommend": "5.14.2",
+        "@algolia/requester-browser-xhr": "5.14.2",
+        "@algolia/requester-fetch": "5.14.2",
+        "@algolia/requester-node-http": "5.14.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@fortawesome/free-solid-svg-icons": "6.6.0",
     "@fortawesome/react-fontawesome": "0.2.2",
     "@openedx/paragon": "^22.0.0",
-    "algoliasearch": "4.24.0",
+    "algoliasearch": "^5.14.2",
     "core-js": "3.39.0",
     "prop-types": "15.8.1",
     "react": "17.0.2",

--- a/src/skills-builder/skills-builder-steps/select-preferences/JobTitleInstantSearch.jsx
+++ b/src/skills-builder/skills-builder-steps/select-preferences/JobTitleInstantSearch.jsx
@@ -8,7 +8,7 @@ import { Search } from '@openedx/paragon/icons';
 
 const JobTitleInstantSearch = ({ onSelected, ...props }) => {
   const { refine } = useSearchBox(props);
-  const { results, status } = useInstantSearch();
+  const { results, status, indexUiState } = useInstantSearch();
   const { hits } = results;
 
   const [inputValue, setInputValue] = useState({});
@@ -41,7 +41,7 @@ const JobTitleInstantSearch = ({ onSelected, ...props }) => {
         )}
       {...props}
     >
-      {hits.map(job => (
+      {!indexUiState.query ? [] : hits.map(job => (
         <Form.AutosuggestOption key={job.id} id={job.name.replaceAll(' ', '-').toLowerCase()}>
           {job.name}
         </Form.AutosuggestOption>

--- a/src/skills-builder/skills-builder-steps/view-results/ViewResults.jsx
+++ b/src/skills-builder/skills-builder-steps/view-results/ViewResults.jsx
@@ -23,7 +23,7 @@ import { setExpandedList } from '../../skills-builder-context/data/actions';
 const ViewResults = () => {
   const { formatMessage } = useIntl();
   const { algolia, state, dispatch } = useContext(SkillsBuilderContext);
-  const { jobSearchIndex, productSearchIndex } = algolia;
+  const { searchClient } = algolia;
   const { careerInterests } = state;
   const [selectedJobTitle, setSelectedJobTitle] = useState('');
   const [jobSkillsList, setJobSkillsList] = useState([]);
@@ -42,7 +42,7 @@ const ViewResults = () => {
     const getAllRecommendations = async () => {
       setIsLoading(true);
       // eslint-disable-next-line max-len
-      const { jobInfo, results } = await getRecommendations(jobSearchIndex, productSearchIndex, careerInterests, productTypes.current);
+      const { jobInfo, results } = await getRecommendations(searchClient, careerInterests, productTypes.current);
       if (results[0]) {
         setFetchError(false);
         setJobSkillsList(jobInfo);
@@ -91,7 +91,7 @@ const ViewResults = () => {
         setIsLoading(false);
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [careerInterests, jobSearchIndex, productSearchIndex]);
+  }, [careerInterests, searchClient]);
 
   useEffect(() => {
     setSelectedRecommendations(productRecommendations.find(rec => rec.name === selectedJobTitle));

--- a/src/skills-builder/skills-builder-steps/view-results/data/service.js
+++ b/src/skills-builder/skills-builder-steps/view-results/data/service.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/prefer-default-export */
 import { searchJobs, getProductRecommendations } from '../../../utils/search';
 
-export async function getRecommendations(jobSearchIndex, productSearchIndex, careerInterests, productTypes) {
-  const jobInfo = await searchJobs(jobSearchIndex, careerInterests);
+export async function getRecommendations(searchClient, careerInterests, productTypes) {
+  const jobInfo = await searchJobs(searchClient, careerInterests);
 
   const results = await Promise.all(jobInfo.map(async (job) => {
     const formattedSkills = job.skills.map(skill => skill.name);
@@ -19,7 +19,7 @@ export async function getRecommendations(jobSearchIndex, productSearchIndex, car
 
     await Promise.all(productTypes.map(async (productType) => {
       const formattedProductType = productType.replace('_', ' ');
-      const response = await getProductRecommendations(productSearchIndex, formattedProductType, formattedSkills);
+      const response = await getProductRecommendations(searchClient, formattedProductType, formattedSkills);
 
       // add a new key to the recommendations object and set the value to the response
       data.recommendations[productType] = response;

--- a/src/skills-builder/test/SkillsBuilder.test.jsx
+++ b/src/skills-builder/test/SkillsBuilder.test.jsx
@@ -21,6 +21,10 @@ jest.mock('react-instantsearch', () => ({
   InstantSearch: jest.fn(() => (null)),
 }));
 
+jest.mock('algoliasearch', () => ({
+  algoliasearch: jest.fn(),
+}));
+
 describe('skills-builder', () => {
   beforeAll(() => {
     useVisibilityFlags.mockImplementation(() => (DEFAULT_VISIBILITY_FLAGS));

--- a/src/skills-builder/test/setupSkillsBuilder.jsx
+++ b/src/skills-builder/test/setupSkillsBuilder.jsx
@@ -19,7 +19,10 @@ jest.mock('react-instantsearch', () => ({
   InstantSearch: ({ children }) => (<div>{children}</div>),
   Configure: jest.fn(() => (null)),
   useSearchBox: jest.fn(() => ({ refine: jest.fn() })),
-  useInstantSearch: jest.fn(() => ({ results: { hits: mockData.hits } })),
+  useInstantSearch: jest.fn(() => ({
+    results: { hits: mockData.hits },
+    indexUiState: { query: true },
+  })),
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -47,8 +50,8 @@ export const contextValue = {
   algolia: {
     // Without this, tests would fail to destructure `searchClient` in the <JobTitleSelect> component
     searchClient: {},
-    productSearchIndex: {},
-    jobSearchIndex: {},
+    productSearchIndex: '',
+    jobSearchIndex: '',
   },
 };
 

--- a/src/skills-builder/utils/tests/search.test.js
+++ b/src/skills-builder/utils/tests/search.test.js
@@ -1,3 +1,4 @@
+import { mergeConfig } from '@edx/frontend-platform';
 import {
   formatFacetFilterData,
   getProductRecommendations,
@@ -21,11 +22,20 @@ const mockAlgoliaResult = {
   ],
 };
 
-const mockIndex = {
-  search: jest.fn().mockImplementation(() => mockAlgoliaResult),
+const mockClient = {
+  searchSingleIndex: jest.fn().mockImplementation(() => mockAlgoliaResult),
 };
 
+const mockAlgoliaJobsIndexName = 'jobs-index';
+const mockAlgoliaProductIndexName = 'product-index';
+
 describe('Algolias utility function', () => {
+  beforeAll(async () => {
+    mergeConfig({
+      ALGOLIA_JOBS_INDEX_NAME: mockAlgoliaJobsIndexName,
+      ALGOLIA_PRODUCT_INDEX_NAME: mockAlgoliaProductIndexName,
+    });
+  });
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -42,9 +52,12 @@ describe('Algolias utility function', () => {
       ],
     };
 
-    const results = await searchJobs(mockIndex, ['Enchanter']);
-    expect(mockIndex.search).toHaveBeenCalledTimes(1);
-    expect(mockIndex.search).toHaveBeenCalledWith('', expectedSearchParameters);
+    const results = await searchJobs(mockClient, ['Enchanter']);
+    expect(mockClient.searchSingleIndex).toHaveBeenCalledTimes(1);
+    expect(mockClient.searchSingleIndex).toHaveBeenCalledWith({
+      indexName: mockAlgoliaJobsIndexName,
+      searchParams: expectedSearchParameters,
+    });
     expect(results).toEqual(mockAlgoliaResult.hits);
   });
 
@@ -61,9 +74,12 @@ describe('Algolias utility function', () => {
       ],
     };
 
-    const results = await getProductRecommendations(mockIndex, 'Course', ['Sword Lobbing']);
-    expect(mockIndex.search).toHaveBeenCalledTimes(1);
-    expect(mockIndex.search).toHaveBeenCalledWith('', expectedSearchParameters);
+    const results = await getProductRecommendations(mockClient, 'Course', ['Sword Lobbing']);
+    expect(mockClient.searchSingleIndex).toHaveBeenCalledTimes(1);
+    expect(mockClient.searchSingleIndex).toHaveBeenCalledWith({
+      indexName: mockAlgoliaProductIndexName,
+      searchParams: expectedSearchParameters,
+    });
     expect(results).toEqual(mockAlgoliaResult.hits);
   });
 


### PR DESCRIPTION
Upgrade `algoliasearch` package to v5.

This required a few changes to the implementation:

- the `searchClient` is now what's primarily used to conduct the search — we no longer need to initiate each index
- the logic that handles empty queries has been moved from the hook to the component level

There are no visual changes.