### PR TITLE
feat: skills upgrade the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,21 +33,21 @@
     "url": "https://github.com/openedx/frontend-app-skills/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@edx/elm-theme@^1.11.0",
+    "@edx/brand": "npm:@edx/elm-theme@^1.11.1",
     "@edx/frontend-component-footer-edx": "^8.0.0",
-    "@edx/frontend-platform": "8.5.4",
+    "@edx/frontend-platform": "8.5.5",
     "@fortawesome/fontawesome-svg-core": "6.7.2",
     "@fortawesome/free-brands-svg-icons": "6.7.2",
     "@fortawesome/free-regular-svg-icons": "6.7.2",
     "@fortawesome/free-solid-svg-icons": "6.7.2",
     "@fortawesome/react-fontawesome": "0.2.6",
-    "@openedx/paragon": "^23.14.0",
+    "@openedx/paragon": "^23.19.2",
     "algoliasearch": "^5.14.2",
-    "core-js": "3.48.0",
+    "core-js": "3.49.0",
     "prop-types": "15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-instantsearch": "^7.0.2",
+    "react-instantsearch": "^7.29.0",
     "react-router": "6.30.3",
     "react-router-dom": "6.30.3",
     "regenerator-runtime": "0.14.1"
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@edx/browserslist-config": "^1.1.1",
     "@edx/reactifex": "^2.1.1",
-    "@openedx/frontend-build": "14.6.2",
+    "@openedx/frontend-build": "14.6.3",
     "@testing-library/react": "^16.2.0",
     "husky": "9.1.7",
     "jest": "30.2.0"


### PR DESCRIPTION

<img width="1729" height="774" alt="image" src="https://github.com/user-attachments/assets/346b00a2-2926-46ea-9860-5c2688d6c248" />
<img width="1808" height="815" alt="image" src="https://github.com/user-attachments/assets/6a04a4a8-7b58-41b4-b45e-f84b6e41679b" />
<img width="1529" height="812" alt="image" src="https://github.com/user-attachments/assets/8f1b3349-ca07-4048-b1f6-61544ee38311" />

It loaded the frontend-app-skills with port 1992 - after login port 18000.
After entering the necessary details and  click on SHow Recommendations it landed to the other screen as attached.